### PR TITLE
Fix-up jinja

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,10 @@
 {% set version="3.11.1" %}
+{% set year="2016" %}
 {% set version_split=version.split(".") %}
 {% set major=version_split[0] %}
-{% set minor=version_split[1]|int * 100 %}
+{% set minor=version_split[1]|int * 10 %}
 {% set bugfix=version_split[2]|int * 100 %}
-{% set version_coded=(major ~ (minor|string)[:3] ~ (bugfix|string)[:3]) %}
+{% set version_coded=(major ~ (("%03d" % minor)|string) ~ (("%03d" % bugfix)|string)) %}
 
 package:
   name: sqlite
@@ -11,7 +12,7 @@ package:
 
 source:
   fn: sqlite-autoconf-{{ version_coded }}.tar.gz
-  url: https://www.sqlite.org/2016/sqlite-autoconf-{{ version_coded }}.tar.gz
+  url: https://www.sqlite.org/{{ year }}/sqlite-autoconf-{{ version_coded }}.tar.gz
   sha1: c4b4dcd735a4daf5a2e2bb90f374484c8d4dad29
 
 build:


### PR DESCRIPTION
Fixes-up jinja to include the year. Also, updates it so that it handles single digit minor version numbers.