### PR TITLE
Drop license_family

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,6 @@ test:
 about:
   home: http://www.sqlite.org/
   license: Public-Domain (http://www.sqlite.org/copyright.html)
-  license_family: Public-Domain
   summary: 'Implements a self-contained, zero-configuration, SQL database engine.'
 
 extra:


### PR DESCRIPTION
As fixing this hasn't worked thus far, am proposing we just drop this field entirely. After all it appears it is on its way out. Currently it is causing this sort of license_family causes feedstocks update and team update to fail.

xref: https://github.com/conda/conda-build/pull/1761
xref: https://github.com/conda/conda-build/pull/1744
xref: https://github.com/conda/conda-build/issues/1780
ref: https://travis-ci.org/conda-forge/conda-forge.github.io/jobs/211185472
xref: https://github.com/conda-forge/bagit-feedstock/pull/4