### PR TITLE
Fix macOS ncurses

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-export LDFLAGS="$LDFLAGS $(pkg-config --libs ncurses readline)"
-export CPPFLAGS="$CPPFLAGS $(pkg-config --cflags-only-I ncurses readline)"
-export CFLAGS="$CFLAGS $(pkg-config --cflags-only-I ncurses readline)"
+export LDFLAGS="$LDFLAGS $(pkg-config --libs ncurses)"
+export CPPFLAGS="$CPPFLAGS $(pkg-config --cflags-only-I ncurses)"
+export CFLAGS="$CFLAGS $(pkg-config --cflags-only-I ncurses)"
 
 if [ $(uname -m) == ppc64le ]; then
     export B="--build=ppc64le-linux"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - expose_symbols.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win and py36]
   features:
     - vc9  # [win and py27]


### PR DESCRIPTION
Somehow the [wrong `ncurses` was linked in the macOS build]( https://travis-ci.org/conda-forge/sqlite-feedstock/builds/321658038#L642 ). This tries again to fix that.