### PR TITLE
Remove readline in favour of libedit

### DIFF
--- a/.ci_support/win_cxx_compilervs2008.yaml
+++ b/.ci_support/win_cxx_compilervs2008.yaml
@@ -1,11 +1,2 @@
 cxx_compiler:
 - vs2008
-ncurses:
-- '6.1'
-pin_run_as_build:
-  ncurses:
-    max_pin: x.x
-  readline:
-    max_pin: x
-readline:
-- '7.0'

--- a/.ci_support/win_cxx_compilervs2015.yaml
+++ b/.ci_support/win_cxx_compilervs2015.yaml
@@ -1,11 +1,2 @@
 cxx_compiler:
 - vs2015
-ncurses:
-- '6.1'
-pin_run_as_build:
-  ncurses:
-    max_pin: x.x
-  readline:
-    max_pin: x
-readline:
-- '7.0'

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Checklist
 * [ ] Used a fork of the feedstock to propose changes
 * [ ] Bumped the build number (if the version is unchanged)
 * [ ] Reset the build number to `0` (if the version changed)
-* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
+* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
 * [ ] Ensured the license file is being packaged.
 
 <!--

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](http://www.appveyor.com/)
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
 and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](http://docs.anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
-[conda-smithy](http://github.com/conda-forge/conda-smithy) has been developed.
+[conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
@@ -100,7 +100,7 @@ build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string).
+   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string)
+   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
    back to 0.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - expose_symbols.patch  # [win]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -24,10 +24,10 @@ requirements:
     - pkg-config             # [not win]
   host:
     - ncurses                # [not win]
-    - readline               # [not win]
+    - libedit                # [not win]
   run:
     - ncurses                # [not win]
-    - readline               # [not win]
+    - libedit                # [not win]
 
 test:
   commands:


### PR DESCRIPTION
readline is gpl, libedit is not.

(I also rerendered, glad to rebase if you want)

Fixes #29

This, or a license change, should be merged in.