### PR TITLE
Split gpl package

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ platform:
 install:
     # If there is a newer build queued for the same PR, cancel this one.
     - cmd: |
-        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/conda-forge/conda-forge-ci-setup-feedstock/master/recipe/ff_ci_pr_build.py', 'ff_ci_pr_build.py')"
+        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/conda-forge/conda-forge-ci-setup-feedstock/branch2.0/recipe/conda_forge_ci_setup/ff_ci_pr_build.py', 'ff_ci_pr_build.py')"
         ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
         del ff_ci_pr_build.py
 
@@ -44,7 +44,7 @@ install:
     - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda.exe install -n root --quiet --yes conda-forge-ci-setup=1
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-ci-setup=2
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
@@ -53,4 +53,4 @@ build: off
 test_script:
     - conda.exe build recipe -m .ci_support\%CONFIG%.yaml --quiet
 deploy_script:
-    - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main -m .ci_support\%CONFIG%.yaml
+    - cmd: upload_package .\ .\recipe .ci_support\%CONFIG%.yaml

--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -1,5 +1,11 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
 cxx_compiler:
 - toolchain_cxx
+docker_image:
+- condaforge/linux-anvil
 ncurses:
 - '6.1'
 pin_run_as_build:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -1,5 +1,9 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
 cxx_compiler:
 - toolchain_cxx
 macos_machine:

--- a/.ci_support/win_cxx_compilervs2008.yaml
+++ b/.ci_support/win_cxx_compilervs2008.yaml
@@ -1,11 +1,2 @@
 cxx_compiler:
 - vs2008
-ncurses:
-- '6.1'
-pin_run_as_build:
-  ncurses:
-    max_pin: x.x
-  readline:
-    max_pin: x
-readline:
-- '7.0'

--- a/.ci_support/win_cxx_compilervs2008.yaml
+++ b/.ci_support/win_cxx_compilervs2008.yaml
@@ -1,2 +1,11 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
 cxx_compiler:
 - vs2008
+pin_run_as_build:
+  readline:
+    max_pin: x
+readline:
+- '7.0'

--- a/.ci_support/win_cxx_compilervs2015.yaml
+++ b/.ci_support/win_cxx_compilervs2015.yaml
@@ -1,2 +1,11 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
 cxx_compiler:
 - vs2015
+pin_run_as_build:
+  readline:
+    max_pin: x
+readline:
+- '7.0'

--- a/.ci_support/win_cxx_compilervs2015.yaml
+++ b/.ci_support/win_cxx_compilervs2015.yaml
@@ -1,11 +1,2 @@
 cxx_compiler:
 - vs2015
-ncurses:
-- '6.1'
-pin_run_as_build:
-  ncurses:
-    max_pin: x.x
-  readline:
-    max_pin: x
-readline:
-- '7.0'

--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -7,27 +7,34 @@
 
 set -xeuo pipefail
 export PYTHONUNBUFFERED=1
+export FEEDSTOCK_ROOT=/home/conda/feedstock_root
+export RECIPE_ROOT=/home/conda/recipe_root
+export CI_SUPPORT=/home/conda/feedstock_root/.ci_support
+export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
 
 cat >~/.condarc <<CONDARC
-
-channels:
- - conda-forge
- - defaults
 
 conda-build:
  root-dir: /home/conda/feedstock_root/build_artifacts
 
-show_channel_urls: true
-
 CONDARC
+
+conda install --yes --quiet conda-forge::conda-forge-ci-setup=2 conda-build
+
+# set up the condarc
+setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artifacts.
 conda clean --lock
 
-conda install --yes --quiet conda-forge-ci-setup=1 conda-build
 source run_conda_forge_build_setup
 
-conda build /home/conda/recipe_root -m /home/conda/feedstock_root/.ci_support/${CONFIG}.yaml --quiet
-upload_or_check_non_existence /home/conda/recipe_root conda-forge --channel=main -m /home/conda/feedstock_root/.ci_support/${CONFIG}.yaml
+# make the build number clobber
+make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+
+conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"  --quiet
+
+upload_package "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 touch "/home/conda/feedstock_root/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.circleci/fast_finish_ci_pr_build.sh
+++ b/.circleci/fast_finish_ci_pr_build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-curl https://raw.githubusercontent.com/conda-forge/conda-forge-ci-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+curl https://raw.githubusercontent.com/conda-forge/conda-forge-ci-setup-feedstock/branch2.0/recipe/conda_forge_ci_setup/ff_ci_pr_build.py | \
      python - -v --ci "circle" "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_BUILD_NUM}" "${CIRCLE_PR_NUMBER}"

--- a/.circleci/run_docker_build.sh
+++ b/.circleci/run_docker_build.sh
@@ -8,7 +8,7 @@
 set -xeuo pipefail
 
 FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
-RECIPE_ROOT=$FEEDSTOCK_ROOT/recipe
+RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"
 
 docker info
 
@@ -29,6 +29,9 @@ if [ -z "$CONFIG" ]; then
     exit 1
 fi
 
+pip install shyaml
+DOCKER_IMAGE=$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil )
+
 mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
@@ -39,7 +42,7 @@ docker run -it \
            -e CONFIG \
            -e BINSTAR_TOKEN \
            -e HOST_USER_ID \
-           condaforge/linux-anvil \
+           $DOCKER_IMAGE \
            bash \
            /home/conda/feedstock_root/.circleci/build_steps.sh
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Checklist
 * [ ] Used a fork of the feedstock to propose changes
 * [ ] Bumped the build number (if the version is unchanged)
 * [ ] Reset the build number to `0` (if the version changed)
-* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
+* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
 * [ ] Ensured the license file is being packaged.
 
 <!--

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 before_install:
     # Fast finish the PR.
     - |
-      (curl https://raw.githubusercontent.com/conda-forge/conda-forge-ci-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+      (curl https://raw.githubusercontent.com/conda-forge/conda-forge-ci-setup-feedstock/branch2.0/recipe/conda_forge_ci_setup/ff_ci_pr_build.py | \
           python - -v --ci "travis" "${TRAVIS_REPO_SLUG}" "${TRAVIS_BUILD_NUMBER}" "${TRAVIS_PULL_REQUEST}") || exit 1
 
     # Remove homebrew.
@@ -46,14 +46,18 @@ install:
       echo ""
       echo "Configuring conda."
       source /Users/travis/miniconda3/bin/activate root
-      conda config --remove channels defaults
-      conda config --add channels defaults
-      conda config --add channels conda-forge
-      conda config --set show_channel_urls true
-      conda install --yes --quiet conda-forge-ci-setup=1
+
+      conda install --yes --quiet conda-forge::conda-forge-ci-setup=2
+      setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+
       source run_conda_forge_build_setup
 
-script:
-  - conda build ./recipe -m ./.ci_support/${CONFIG}.yaml
+    # compiler cleanup
+    - |
+      mangle_compiler ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
-  - upload_or_check_non_existence ./recipe conda-forge --channel=main -m ./.ci_support/${CONFIG}.yaml
+script:
+  # generate the build number clobber
+  - make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+  - conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+  - upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](http://www.appveyor.com/)
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
 and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](http://docs.anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
-[conda-smithy](http://github.com/conda-forge/conda-smithy) has been developed.
+[conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
@@ -100,7 +100,7 @@ build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string).
+   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string)
+   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
    back to 0.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Package license: Public-Domain (http://www.sqlite.org/copyright.html)
 
 Feedstock license: BSD 3-Clause
 
-Summary: Implements a self-contained, zero-configuration, SQL database engine.
+Summary: Library for implementing a self-contained, zero-configuration, SQL database engine.
 
 
 
@@ -23,6 +23,7 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libsqlite-green.svg)](https://anaconda.org/conda-forge/libsqlite) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libsqlite.svg)](https://anaconda.org/conda-forge/libsqlite) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libsqlite.svg)](https://anaconda.org/conda-forge/libsqlite) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libsqlite.svg)](https://anaconda.org/conda-forge/libsqlite) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-sqlite-green.svg)](https://anaconda.org/conda-forge/sqlite) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sqlite.svg)](https://anaconda.org/conda-forge/sqlite) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sqlite.svg)](https://anaconda.org/conda-forge/sqlite) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sqlite.svg)](https://anaconda.org/conda-forge/sqlite) |
 
 Installing sqlite
@@ -34,16 +35,16 @@ Installing `sqlite` from the `conda-forge` channel can be achieved by adding `co
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `sqlite` can be installed with:
+Once the `conda-forge` channel has been enabled, `libsqlite, sqlite` can be installed with:
 
 ```
-conda install sqlite
+conda install libsqlite sqlite
 ```
 
-It is possible to list all of the versions of `sqlite` available on your platform with:
+It is possible to list all of the versions of `libsqlite` available on your platform with:
 
 ```
-conda search sqlite --channel conda-forge
+conda search libsqlite --channel conda-forge
 ```
 
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,7 +10,3 @@ cl /DSQLITE_ENABLE_RTREE shell.c sqlite3.c -Fesqlite3.exe /DSQLITE_EXPORTS
 :: build the dll
 cl /DSQLITE_ENABLE_RTREE sqlite3.c -link -dll -out:sqlite3.dll
 
-COPY sqlite3.exe %LIBRARY_BIN% || exit 1
-COPY sqlite3.dll %LIBRARY_BIN% || exit 1
-COPY sqlite3.lib %LIBRARY_LIB% || exit 1
-COPY sqlite3.h   %LIBRARY_INC% || exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,4 +9,3 @@ cl /DSQLITE_ENABLE_RTREE shell.c sqlite3.c -Fesqlite3.exe /DSQLITE_EXPORTS
 
 :: build the dll
 cl /DSQLITE_ENABLE_RTREE sqlite3.c -link -dll -out:sqlite3.dll
-

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,4 +20,4 @@ fi
 
 make
 make check
-make install
+#make install

--- a/recipe/install_bin.bat
+++ b/recipe/install_bin.bat
@@ -1,2 +1,2 @@
+MKDIR %LIBRARY_BIN%
 COPY sqlite3.exe %LIBRARY_BIN% || exit 1
-

--- a/recipe/install_bin.bat
+++ b/recipe/install_bin.bat
@@ -1,0 +1,2 @@
+COPY sqlite3.exe %LIBRARY_BIN% || exit 1
+

--- a/recipe/install_bin.sh
+++ b/recipe/install_bin.sh
@@ -1,0 +1,1 @@
+install sqlite3 $PREFIX/bin/.

--- a/recipe/install_lib.bat
+++ b/recipe/install_lib.bat
@@ -1,0 +1,4 @@
+COPY sqlite3.dll %LIBRARY_BIN% || exit 1
+COPY sqlite3.lib %LIBRARY_LIB% || exit 1
+COPY sqlite3.h   %LIBRARY_INC% || exit 1
+

--- a/recipe/install_lib.bat
+++ b/recipe/install_lib.bat
@@ -1,4 +1,6 @@
+MKDIR %LIBRARY_BIN%
+MKDIR %LIBRARY_LIB%
+MKDIR %LIBRARY_INC%
 COPY sqlite3.dll %LIBRARY_BIN% || exit 1
 COPY sqlite3.lib %LIBRARY_LIB% || exit 1
 COPY sqlite3.h   %LIBRARY_INC% || exit 1
-

--- a/recipe/install_lib.sh
+++ b/recipe/install_lib.sh
@@ -1,0 +1,3 @@
+ls -lah
+make install
+rm $PREFIX/bin/sqlite3

--- a/recipe/install_lib.sh
+++ b/recipe/install_lib.sh
@@ -1,3 +1,2 @@
-ls -lah
 make install
 rm $PREFIX/bin/sqlite3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,9 +55,6 @@ outputs:
     script: install_bin.sh   # [not win]
     script: install_bin.bat  # [win]
     requirements:
-      host:
-        - ncurses                # [not win]
-        - readline               # [not win]
       run:
         - {{ pin_subpackage("libsqlite", exact=true) }}
         - readline  # [notwin]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,16 +27,19 @@ requirements:
     - readline               # [not win]
 
 
+# By compiling with readline, the /bin/sqlite3 executable becomes
+# subject to the GPL
+# Therefore, we decide to split it to make it clear
+# That the other software is not.
 outputs:
   - name: libsqlite
     files:
-      - include/sqlite3*          # [not win]
-      - share/man/man1/sqlite3*   # [not win]
-      - lib/libsqlite3*           # [not win]
-      - lib/pkgconfig/sqlite3.pc  # [not win]
-      - Library/lib/sqlite3*      # [win]
-      - Library/include/sqlite3*  # [win]
-      - Library/bin/sqlite3.dll   # [win]
+      - lib                      # [not win]
+      - share                    # [not win]
+      - include                  # [not win]
+      - Library/lib/             # [win]
+      - Library/include/         # [win]
+      - Library/bin/sqlite3.dll  # [win]
     requirements:
       - ncurses                   # [notwin]
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,7 @@ outputs:
         - sqlite3 --version
     about:
       home: http://www.sqlite.org/
-      license: GPLv3  # [not win]
+      license: GPL-3.0  # [not win]
       license: Public-Domain (http://www.sqlite.org/copyright.html)  # [win]
       summary: 'Implements a self-contained, zero-configuration, SQL database engine.'
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,7 @@ outputs:
       - Library/bin/sqlite3.exe   # [win]
     requirements:
       run:
-        - libsqlite {{ version }}
+        - {{ pin_subpackage("libsqlite", exact=true) }}
         - readline   # [notwin]
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - expose_symbols.patch  # [win]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -25,23 +25,52 @@ requirements:
   host:
     - ncurses                # [not win]
     - readline               # [not win]
-  run:
-    - ncurses                # [not win]
-    - readline               # [not win]
 
-test:
-  commands:
-    - sqlite3 --version
-    - if not exist %PREFIX%\\Library\bin\sqlite3.dll exit 1    # [win]
-    - if not exist %PREFIX%\\Library\lib\sqlite3.lib exit 1    # [win]
-    - test -f $PREFIX/lib/libsqlite3.dylib                     # [osx]
-    - test -f $PREFIX/lib/libsqlite3.so                        # [linux]
-    - if not exist %PREFIX%\\Library\include\sqlite3.h exit 1  # [win]
-    - test -f $PREFIX/include/sqlite3.h                        # [not win]
+
+outputs:
+  - name: libsqlite
+    files:
+      - include/sqlite3*          # [not win]
+      - share/man/man1/sqlite3*   # [not win]
+      - lib/libsqlite3*           # [not win]
+      - lib/pkgconfig/sqlite3.pc  # [not win]
+      - Library/lib/sqlite3*      # [win]
+      - Library/include/sqlite3*  # [win]
+      - Library/bin/sqlite3.dll   # [win]
+    requirements:
+      - ncurses                   # [notwin]
+    test:
+      commands:
+        - if not exist %PREFIX%\\Library\bin\sqlite3.dll exit 1    # [win]
+        - if not exist %PREFIX%\\Library\lib\sqlite3.lib exit 1    # [win]
+        - test -f $PREFIX/lib/libsqlite3.dylib                     # [osx]
+        - test -f $PREFIX/lib/libsqlite3.so                        # [linux]
+        - if not exist %PREFIX%\\Library\include\sqlite3.h exit 1  # [win]
+        - test -f $PREFIX/include/sqlite3.h                        # [not win]
+    about:
+      home: http://www.sqlite.org/
+      license: Public-Domain (http://www.sqlite.org/copyright.html)
+      summary: 'Library for implementing a self-contained, zero-configuration, SQL database engine.'
+  - name: sqlite
+    files:
+      - bin/sqlite3               # [not win]
+      - Library/bin/sqlite3.exe   # [win]
+    requirements:
+      run:
+        - libsqlite =={{ version }}
+        - readline
+    test:
+      commands:
+        - sqlite3 --version
+    about:
+      home: http://www.sqlite.org/
+      license: GPLv3  # [not win]
+      license: Public-Domain (http://www.sqlite.org/copyright.html)  # [win]
+      summary: 'Implements a self-contained, zero-configuration, SQL database engine.'
 
 about:
   home: http://www.sqlite.org/
-  license: Public-Domain (http://www.sqlite.org/copyright.html)
+  license: GPLv3 or Public Domain
   summary: 'Implements a self-contained, zero-configuration, SQL database engine.'
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,22 +26,16 @@ requirements:
     - ncurses                # [not win]
     - readline               # [not win]
 
-
-# By compiling with readline, the /bin/sqlite3 executable becomes
-# subject to the GPL
-# Therefore, we decide to split it to make it clear
-# That the other software is not.
 outputs:
   - name: libsqlite
-    files:
-      - lib                      # [not win]
-      - share                    # [not win]
-      - include                  # [not win]
-      - Library/lib/             # [win]
-      - Library/include/         # [win]
-      - Library/bin/sqlite3.dll  # [win]
+    script: install_lib.sh   # [not win]
+    script: install_lib.bat  # [win]
     requirements:
-      - ncurses                   # [notwin]
+      host:
+        - ncurses                # [not win]
+        - readline               # [not win]
+      run:
+        - ncurses   # [not win]
     test:
       commands:
         - if not exist %PREFIX%\\Library\bin\sqlite3.dll exit 1    # [win]
@@ -55,25 +49,29 @@ outputs:
       license: Public-Domain (http://www.sqlite.org/copyright.html)
       summary: 'Library for implementing a self-contained, zero-configuration, SQL database engine.'
   - name: sqlite
-    files:
-      - bin/sqlite3               # [not win]
-      - Library/bin/sqlite3.exe   # [win]
+    script: install_bin.sh   # [not win]
+    script: install_bin.bat  # [win]
     requirements:
+      host:
+        - ncurses                # [not win]
+        - readline               # [not win]
       run:
         - {{ pin_subpackage("libsqlite", exact=true) }}
-        - readline   # [notwin]
+        - readline  # [notwin]
     test:
+      # it can pick up build environment's sqlite3, so explicitly check for the file too
       commands:
+        - test -f $PREFIX/bin/sqlite3                              # [not win]
+        - if not exist %PREFIX%\\Library\bin\sqlite3.exe exit 1    # [win]
         - sqlite3 --version
     about:
       home: http://www.sqlite.org/
-      license: GPL-3.0  # [not win]
-      license: Public-Domain (http://www.sqlite.org/copyright.html)  # [win]
+      license: Public-Domain (http://www.sqlite.org/copyright.html)
       summary: 'Implements a self-contained, zero-configuration, SQL database engine.'
 
 about:
   home: http://www.sqlite.org/
-  license: GPL-3.0 (unix exe) and Public-Domain (other)
+  license: Public-Domain (http://www.sqlite.org/copyright.html)
   summary: 'Implements a self-contained, zero-configuration, SQL database engine.'
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,9 @@ outputs:
     requirements:
       host:
         - ncurses                # [not win]
+        # While readline isn't necessary to run
+        # It is necessary to trick `make` into thinking
+        # nothing has changed and not to attempt to recompile
         - readline               # [not win]
       run:
         - ncurses   # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,7 +70,7 @@ outputs:
 
 about:
   home: http://www.sqlite.org/
-  license: GPLv3 or Public Domain
+  license: GPL-3.0 (unix exe) and Public-Domain (other)
   summary: 'Implements a self-contained, zero-configuration, SQL database engine.'
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,8 +57,8 @@ outputs:
       - Library/bin/sqlite3.exe   # [win]
     requirements:
       run:
-        - libsqlite =={{ version }}
-        - readline
+        - libsqlite {{ version }}
+        - readline   # [notwin]
     test:
       commands:
         - sqlite3 --version


### PR DESCRIPTION
Superseeds #30 (suggested using libedit instead)
Fixes #29 

Splits the package into a GPL'ed portion (the binary) and the non-gpl'ed portion (the library). See results from [ldd](https://github.com/conda-forge/sqlite-feedstock/pull/30#issuecomment-414130501).

(I didn't test it with windows or mac, lets see what the CI's say)

The binary is compiled with readline support, so it must have a GPLv3 license.

Notes from the discussion in #30
@bgruening suggested looking at how [debian packages things](https://github.com/conda-forge/sqlite-feedstock/pull/30#issuecomment-414131251)

I am unfamiliar with debian packaging, but it doesn't seem that they list a license in their package.

They they split their package into an executable package and library.


Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.


XREF:
Issue on Continuum repo: 
* https://github.com/ContinuumIO/anaconda-issues/issues/307
* https://github.com/ContinuumIO/anaconda-recipes/issues/27