### PR TITLE
Enable column metadata on Windows builds

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -28,7 +28,7 @@ jobs:
   # configure qemu binfmt-misc running.  This allows us to run docker containers 
   # embedded qemu-static
   - script: |
-      docker run --rm --privileged multiarch/qemu-user-static:register
+      docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
       ls /proc/sys/fs/binfmt_misc/
     condition: not(startsWith(variables['CONFIG'], 'linux_64'))
     displayName: Configure binfmt_misc

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,10 +5,19 @@ set PLATFORM=x64
 )
 
 :: build the shell
-cl /DSQLITE_ENABLE_RTREE /DSQLITE_ENABLE_GEOPOLY shell.c sqlite3.c -Fesqlite3.exe /DSQLITE_EXPORTS
+cl ^
+    /DSQLITE_ENABLE_RTREE ^
+    /DSQLITE_ENABLE_GEOPOLY ^
+    /DSQLITE_ENABLE_COLUMN_METADATA=1 ^
+    shell.c sqlite3.c -Fesqlite3.exe ^
+    /DSQLITE_EXPORTS
 
 :: build the dll
-cl /DSQLITE_ENABLE_RTREE /DSQLITE_ENABLE_GEOPOLY sqlite3.c -link -dll -out:sqlite3.dll
+cl ^
+    /DSQLITE_ENABLE_RTREE ^
+    /DSQLITE_ENABLE_GEOPOLY ^
+    /DSQLITE_ENABLE_COLUMN_METADATA=1 ^
+    sqlite3.c -link -dll -out:sqlite3.dll
 
 COPY sqlite3.exe %LIBRARY_BIN% || exit 1
 COPY sqlite3.dll %LIBRARY_BIN% || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - expose_symbols.patch  # [win]
 
 build:
-  number: 1000
+  number: 1001
   run_exports:
     # sometimes adds new symbols.  Default behavior is OK.
     #    https://abi-laboratory.pro/tracker/timeline/sqlite/


### PR DESCRIPTION
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This PR sets `SQLITE_ENABLE_COLUMN_METADATA` for the Windows build like is done on Linux and Mac. I need this change to enable the `sqlite3_column_table_name` function, which is only available with the extra option according to the [the sqlite compilation docs](https://www.sqlite.org/compile.html) to get the QGIS Windows build working (see conda-forge/qgis-feedstock#45).

There are a few other compilation options that differ on the Windows build, but I haven't looked up what they do or tested them so I'm just adding the one for now. Happy to make this more of a "bring platforms to parity" PR if that would be of interest. Apologies ahead of time if I'm missing reasons for it not being enabled already!