### PR TITLE
Split sqlite into two packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About sqlite
-============
+About sqlite-split
+==================
 
 Home: http://www.sqlite.org/
 
@@ -97,53 +97,54 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libsqlite-green.svg)](https://anaconda.org/conda-forge/libsqlite) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libsqlite.svg)](https://anaconda.org/conda-forge/libsqlite) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libsqlite.svg)](https://anaconda.org/conda-forge/libsqlite) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libsqlite.svg)](https://anaconda.org/conda-forge/libsqlite) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-sqlite-green.svg)](https://anaconda.org/conda-forge/sqlite) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/sqlite.svg)](https://anaconda.org/conda-forge/sqlite) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/sqlite.svg)](https://anaconda.org/conda-forge/sqlite) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/sqlite.svg)](https://anaconda.org/conda-forge/sqlite) |
 
-Installing sqlite
-=================
+Installing sqlite-split
+=======================
 
-Installing `sqlite` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `sqlite-split` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `sqlite` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `libsqlite, sqlite` can be installed with `conda`:
 
 ```
-conda install sqlite
-```
-
-or with `mamba`:
-
-```
-mamba install sqlite
-```
-
-It is possible to list all of the versions of `sqlite` available on your platform with `conda`:
-
-```
-conda search sqlite --channel conda-forge
+conda install libsqlite sqlite
 ```
 
 or with `mamba`:
 
 ```
-mamba search sqlite --channel conda-forge
+mamba install libsqlite sqlite
+```
+
+It is possible to list all of the versions of `libsqlite` available on your platform with `conda`:
+
+```
+conda search libsqlite --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search libsqlite --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search sqlite --channel conda-forge
+mamba repoquery search libsqlite --channel conda-forge
 
-# List packages depending on `sqlite`:
-mamba repoquery whoneeds sqlite --channel conda-forge
+# List packages depending on `libsqlite`:
+mamba repoquery whoneeds libsqlite --channel conda-forge
 
-# List dependencies of `sqlite`:
-mamba repoquery depends sqlite --channel conda-forge
+# List dependencies of `libsqlite`:
+mamba repoquery depends libsqlite --channel conda-forge
 ```
 
 
@@ -188,17 +189,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating sqlite-feedstock
-=========================
+Updating sqlite-split-feedstock
+===============================
 
-If you would like to improve the sqlite recipe or build a new
+If you would like to improve the sqlite-split recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/sqlite-feedstock are
+Note that all branches in the conda-forge/sqlite-split-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@
 {% set version_coded=(major ~ (("%03d" % minor)|string) ~ (("%03d" % bugfix)|string)) %}
 
 package:
-  name: sqlite
+  name: sqlite-split
   version: {{ version }}
 
 source:
@@ -17,11 +17,7 @@ source:
     - expose_symbols.patch  # [win]
 
 build:
-  number: 0
-  run_exports:
-    # sometimes adds new symbols.  Default behavior is OK.
-    #    https://abi-laboratory.pro/tracker/timeline/sqlite/
-    - {{ pin_subpackage('sqlite') }}
+  number: 1
 
 requirements:
   build:
@@ -32,22 +28,65 @@ requirements:
     - ncurses  # [not win]
     - readline  # [not win]
     - zlib  # [not win]
-  run:
-    - ncurses  # [not win]
-    - readline  # [not win]
-    - zlib  # [not win]
 
-test:
-  commands:
-    - sqlite3 --version
-    - if not exist %PREFIX%\\Library\bin\sqlite3.dll exit 1  # [win]
-    - if not exist %PREFIX%\\Library\lib\sqlite3.lib exit 1  # [win]
-    - test -f $PREFIX/lib/libsqlite3${SHLIB_EXT}  # [not win]
-    - test ! -f $PREFIX/lib/libsqlite3.a  # [not win]
-    - if not exist %PREFIX%\\Library\include\sqlite3.h exit 1  # [win]
-    - if not exist %PREFIX%\\Library\include\sqlite3ext.h exit 1  # [win]
-    - test -f $PREFIX/include/sqlite3.h  # [not win]
-    - test -f $PREFIX/include/sqlite3ext.h  # [not win]
+
+outputs:
+  - name: libsqlite
+    build:
+      run_exports:
+        # sometimes adds new symbols.  Default behavior is OK.
+        #    https://abi-laboratory.pro/tracker/timeline/sqlite/
+        - {{ pin_subpackage('libsqlite') }}
+    files:
+      - include/sqlite*.h          # [unix]
+      - lib/libsqlite*             # [unix]
+      - lib/pkgconfig/sqlite3.pc   # [unix]
+      - Library\bin\sqlite3.dll    # [win]
+      - Library\lib\sqlite3.lib    # [win]
+      - Library\include\sqlite*.h  # [win]
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - make  # [not win]
+        - libtool  # [not win]
+      host:
+        # readline and ncurses are only required by the executable
+        # not the library. Leaving it out of the host requirements
+        # ensures it doesn't appear in the run section (through run_export)
+        - zlib  # [not win]
+    test:
+      commands:
+        - if not exist %PREFIX%\\Library\bin\sqlite3.dll exit 1  # [win]
+        - if not exist %PREFIX%\\Library\lib\sqlite3.lib exit 1  # [win]
+        - test -f $PREFIX/lib/libsqlite3${SHLIB_EXT}  # [not win]
+        - test ! -f $PREFIX/lib/libsqlite3.a  # [not win]
+        - if not exist %PREFIX%\\Library\include\sqlite3.h exit 1  # [win]
+        - if not exist %PREFIX%\\Library\include\sqlite3ext.h exit 1  # [win]
+        - test -f $PREFIX/include/sqlite3.h  # [not win]
+        - test -f $PREFIX/include/sqlite3ext.h  # [not win]
+  - name: sqlite
+    build:
+      run_exports:
+        # sometimes adds new symbols.  Default behavior is OK.
+        #    https://abi-laboratory.pro/tracker/timeline/sqlite/
+        - {{ pin_subpackage('libsqlite') }}
+    files:
+      - bin/sqlite3              # [unix]
+      - Library\bin\sqlite3.exe  # [win]
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - make  # [not win]
+        - libtool  # [not win]
+      host:
+        - ncurses  # [not win]
+        - readline  # [not win]
+        - zlib  # [not win]
+      run:
+        - {{ pin_subpackage('libsqlite', exact=True) }}
+    test:
+      commands:
+        - sqlite3 --version
 
 about:
   home: http://www.sqlite.org/


### PR DESCRIPTION
I would like to split sqlite into two packageS:

- The library (no dependency on readline)
- The executabe (dependency on readline)

This should help users that require a GPL free compilation of sqlite to make the clear case that they do not in fact depend on readline, a GPL library.

Let me know what you all thing.

To create the file list, i had to go through the linux, and windows packages manually and list out the files. This was dooable since this is a small package.


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
