### PR TITLE
sqlite v3.49.1 fix misdetection of line-editing capability when cross-compiling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jakirkham @mingwandroid @msarahan @ocefpaf
+* @flaviomartins @jakirkham @mingwandroid @msarahan @ocefpaf

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@flaviomartins](https://github.com/flaviomartins/)
 * [@jakirkham](https://github.com/jakirkham/)
 * [@mingwandroid](https://github.com/mingwandroid/)
 * [@msarahan](https://github.com/msarahan/)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -53,7 +53,7 @@ fi
             --enable-threadsafe \
             --enable-load-extension \
             --disable-static \
-            --disable-editline \
+            --with-readline-header="${CONDA_PREFIX}/include/readline/readline.h" \
             CFLAGS="${CFLAGS} -I${PREFIX}/include" \
             LDFLAGS="${LDFLAGS} -L${PREFIX}/lib" \
             ${PPC64LE}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,9 +7,6 @@ if [[ "${BUILD}" != "${HOST}" ]]; then
   export PATH=${PWD}:$PATH
 fi
 
-# Get an updated config.sub and config.guess
-cp $BUILD_PREFIX/share/libtool/build-aux/config.* .
-
 export CFLAGS="${CFLAGS} -DSQLITE_DQS=0 \
                          -DSQLITE_ENABLE_COLUMN_METADATA \
                          -DSQLITE_ENABLE_DBSTAT_VTAB \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - expose_symbols.patch  # [win]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -110,3 +110,4 @@ extra:
     - msarahan
     - ocefpaf
     - mingwandroid
+    - flaviomartins

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - {{ compiler('c') }}
     - {{ stdlib("c") }}
     - make  # [not win]
-    - libtool  # [not win]
   host:
     - ncurses  # [not win]
     - readline  # [not win]
@@ -50,7 +49,6 @@ outputs:
         - {{ compiler('c') }}
         - {{ stdlib("c") }}
         - make  # [not win]
-        - libtool  # [not win]
       host:
         # readline and ncurses are only required by the executable
         # not the library. Leaving it out of the host requirements
@@ -80,7 +78,6 @@ outputs:
         - {{ compiler('c') }}
         - {{ stdlib("c") }}
         - make  # [not win]
-        - libtool  # [not win]
       host:
         - ncurses  # [not win]
         - readline  # [not win]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

When cross-compiling (e.g., linux-aarch64) configure script skips readline detection

```
Checking for line-editing capability...
WARNING: Skipping check for readline.h because we're cross-compiling.
Line-editing support for the sqlite3 shell: none
```