### PR TITLE
Remove SQLITE_DQS=0 compilation flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Rattler-build's artifacts are in `output` when not specifying anything.
 /output
+# Pixi's configuration
+.pixi

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,7 +7,6 @@ set PLATFORM=x64
 :: build the shell
 cl ^
     /O2 ^
-    -DSQLITE_DQS=0 ^
     -DSQLITE_ENABLE_COLUMN_METADATA ^
     -DSQLITE_ENABLE_DBSTAT_VTAB ^
     -DSQLITE_ENABLE_DESERIALIZE ^
@@ -41,7 +40,6 @@ cl ^
 :: build the dll
 cl ^
     /O2 ^
-    -DSQLITE_DQS=0 ^
     -DSQLITE_ENABLE_COLUMN_METADATA ^
     -DSQLITE_ENABLE_DBSTAT_VTAB ^
     -DSQLITE_ENABLE_DESERIALIZE ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,7 +7,7 @@ if [[ "${BUILD}" != "${HOST}" ]]; then
   export PATH=${PWD}:$PATH
 fi
 
-export CFLAGS="${CFLAGS} -DSQLITE_DQS=0 \
+export CFLAGS="${CFLAGS} \
                          -DSQLITE_ENABLE_COLUMN_METADATA \
                          -DSQLITE_ENABLE_DBSTAT_VTAB \
                          -DSQLITE_ENABLE_DESERIALIZE \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - expose_symbols.patch  # [win]
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
This is a **proposal** to set the DQS compilation flag to the default during compilation. In https://github.com/conda-forge/sqlite-feedstock/pull/124, this was set to OFF, even though the default is ON. The issues caused by this can be seen in #130.

If nothing else, we can use this PR as a place to discuss the choice of setting DQS=OFF.

CC @flaviomartins



<!--
Please add any other relevant info below:
-->

Closes #130 
