### PR TITLE
ENH: Fix build options in bld.bat to use OPT_FEATURE_FLAGS instead of OPTIONS

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -33,8 +33,7 @@ set OPTIONS=-DSQLITE_DQS=3 ^
 :: Build DLL and shell executable
 nmake /f Makefile.msc DYNAMIC_SHELL=1 ^
                       USE_NATIVE_LIBPATHS=1 ^
-                      MINIMAL_AMALGAMATION=1 ^
-                      OPTIONS="%OPTIONS%"
+                      OPT_FEATURE_FLAGS="%OPTIONS%"
 if %ERRORLEVEL% neq 0 exit 1
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@
 {% set minor = version_split[1]|int * 10 %}
 {% set bugfix = version_split[2]|int * 100 %}
 {% set version_coded=(major ~ (("%03d" % minor)|string) ~ (("%03d" % bugfix)|string)) %}
-{% set build_number = 6 %}
+{% set build_number = 7 %}
 {% if not with_icu %}
 # deprioritize with_icu variant via build number
 {% set build_number = build_number + 100 %}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
