### PR TITLE
Fix SPDX license expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/sqlite-feedstoc
 
 Home: http://www.sqlite.org/
 
-Package license: [Unlicense](http://www.sqlite.org/copyright.html)
+Package license: [blessing](http://www.sqlite.org/copyright.html)
 
 Summary: Implements a self-contained, zero-configuration, SQL database engine
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@
 {% set minor = version_split[1]|int * 10 %}
 {% set bugfix = version_split[2]|int * 100 %}
 {% set version_coded=(major ~ (("%03d" % minor)|string) ~ (("%03d" % bugfix)|string)) %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 {% if not with_icu %}
 # deprioritize with_icu variant via build number
 {% set build_number = build_number + 100 %}
@@ -101,7 +101,7 @@ outputs:
 
 about:
   home: http://www.sqlite.org/
-  license: Unlicense
+  license: blessing
   license_url: http://www.sqlite.org/copyright.html
   summary: Implements a self-contained, zero-configuration, SQL database engine
   description: |


### PR DESCRIPTION
SPDX defines a specific license identifier for the SQLite public domain dedication.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
